### PR TITLE
add static positioning mixin

### DIFF
--- a/axis/layout.styl
+++ b/axis/layout.styl
@@ -25,8 +25,8 @@ clearfix()
     i += 1
 
 // Mixin: Positions
-// Syntax shortcuts for absolute, relative, and fixed positioning. Ported
-// from nib: https://github.com/tj/nib/blob/master/lib/nib/positions.styl
+// Syntax shortcuts for absolute, relative, fixed, and static positioning. Mostly
+// ported from nib: https://github.com/tj/nib/blob/master/lib/nib/positions.styl
 
 fixed()
   -pos('fixed', arguments)
@@ -36,6 +36,9 @@ absolute()
 
 relative()
   -pos('relative', arguments)
+
+static()
+  -pos('static', arguments)
 
 // Mixin: Size
 // Shortcut for setting width and height quickly. If passed one value, sets this

--- a/test/fixtures/layout/position.css
+++ b/test/fixtures/layout/position.css
@@ -8,3 +8,8 @@
   top: auto;
   right: auto;
 }
+.static {
+  position: static;
+  bottom: 12px;
+  left: 34px;
+}

--- a/test/fixtures/layout/position.styl
+++ b/test/fixtures/layout/position.styl
@@ -3,3 +3,6 @@
 
 .auto
     relative top auto right auto
+
+.static
+    static bottom 12px left 34px

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -39,37 +39,37 @@ describe 'forms', ->
     compile_and_match(path.join(@path, 'input.styl'), done)
 
   it 'input-search', (done) ->
-      compile_and_match(path.join(@path, 'input-search.styl'), done)
+    compile_and_match(path.join(@path, 'input-search.styl'), done)
 
   it 'input-disabled', (done) ->
-      compile_and_match(path.join(@path, 'input-disabled.styl'), done)
+    compile_and_match(path.join(@path, 'input-disabled.styl'), done)
 
   it 'label', (done) ->
-      compile_and_match(path.join(@path, 'label.styl'), done)
+    compile_and_match(path.join(@path, 'label.styl'), done)
 
   it 'field', (done) ->
-      compile_and_match(path.join(@path, 'field.styl'), done)
+    compile_and_match(path.join(@path, 'field.styl'), done)
 
   it 'input-error', (done) ->
-      compile_and_match(path.join(@path, 'input-error.styl'), done)
+    compile_and_match(path.join(@path, 'input-error.styl'), done)
 
   it 'field-error', (done) ->
-      compile_and_match(path.join(@path, 'field-error.styl'), done)
+    compile_and_match(path.join(@path, 'field-error.styl'), done)
 
   it 'input-warning', (done) ->
-      compile_and_match(path.join(@path, 'input-warning.styl'), done)
+    compile_and_match(path.join(@path, 'input-warning.styl'), done)
 
   it 'field-warning', (done) ->
-      compile_and_match(path.join(@path, 'field-warning.styl'), done)
+    compile_and_match(path.join(@path, 'field-warning.styl'), done)
 
   it 'input-success', (done) ->
-      compile_and_match(path.join(@path, 'input-success.styl'), done)
+    compile_and_match(path.join(@path, 'input-success.styl'), done)
 
   it 'field-success', (done) ->
-      compile_and_match(path.join(@path, 'field-success.styl'), done)
+    compile_and_match(path.join(@path, 'field-success.styl'), done)
 
   it 'autofill', (done) ->
-      compile_and_match(path.join(@path, 'autofill.styl'), done)
+    compile_and_match(path.join(@path, 'autofill.styl'), done)
 
   it 'radio', (done) ->
     compile_and_match(path.join(@path, 'radio.styl'), done)


### PR DESCRIPTION
Kind of surprised that this isn't in nib and/or axis, but whatever. It does add an extra `position: static` CSS statement, but sometimes it might be desirable. I personally did it because I prefer one-liners. :+1: 

I also fixed indentation on the tests (coffeelint was bugging me to fix it).