### PR TITLE
Revert applying default styling to class-less links only

### DIFF
--- a/axis/typography.styl
+++ b/axis/typography.styl
@@ -515,7 +515,7 @@ typography()
   small
     small()
 
-  a[href]:not([class])
+  a
     link()
 
   blockquote

--- a/test/fixtures/additive/framework.css
+++ b/test/fixtures/additive/framework.css
@@ -109,20 +109,20 @@ small {
   opacity: 0.6;
   font-weight: normal;
 }
-a[href]:not([class]) {
+a {
   color: #0074d9;
   text-decoration: none;
   -webkit-transition: all .3s ease;
   transition: all .3s ease;
   border-bottom: 1px solid transparent;
 }
-a[href]:not([class]):hover {
+a:hover {
   border-bottom: 1px solid;
 }
-a[href]:not([class]):hover {
+a:hover {
   color: #0063b8;
 }
-a[href]:not([class]):visited {
+a:visited {
   opacity: 0.8;
 }
 blockquote {


### PR DESCRIPTION
Applying default link styling only to links that didn't had any class broke composability since required applying the default style to them if you were composing a component and adding classes.