### PR TITLE
Make range inputs stay big while you're dragging them

### DIFF
--- a/axis/forms.styl
+++ b/axis/forms.styl
@@ -262,7 +262,7 @@ range-input($color = #0074d9, $track-width = 100%, $thumb-size = 2em, $track-hei
     &:hover
       cursor: pointer
 
-    &:hover, &.active
+    &:hover, &:active
       transform: scale(1.2)
 
     &:active
@@ -289,7 +289,7 @@ range-input($color = #0074d9, $track-width = 100%, $thumb-size = 2em, $track-hei
     background: $color
     transition: all 0.2s ease
 
-    &:hover, &.active
+    &:hover, &:active
       transform: scale(1.2)
 
     &:active

--- a/axis/forms.styl
+++ b/axis/forms.styl
@@ -260,8 +260,10 @@ range-input($color = #0074d9, $track-width = 100%, $thumb-size = 2em, $track-hei
     transition: all 0.2s ease
 
     &:hover
-      transform: scale(1.2)
       cursor: pointer
+
+    &:hover, &.active
+      transform: scale(1.2)
 
     &:active
       background: darken($color, 15%)
@@ -287,7 +289,7 @@ range-input($color = #0074d9, $track-width = 100%, $thumb-size = 2em, $track-hei
     background: $color
     transition: all 0.2s ease
 
-    &:hover
+    &:hover, &.active
       transform: scale(1.2)
 
     &:active


### PR DESCRIPTION
Even if you move the mouse above or below the input.
